### PR TITLE
Updated to new way of retrieving the source model as recommended by Django from 1.8

### DIFF
--- a/django_admin_generator/management/commands/admin_generator.py
+++ b/django_admin_generator/management/commands/admin_generator.py
@@ -159,7 +159,8 @@ class AdminModel(object):
     def _process_many_to_many(self, meta):
         raw_id_threshold = self.raw_id_threshold
         for field in meta.local_many_to_many:
-            related_objects = field.related.parent_model.objects.all()
+            related_model = getattr(field.related, 'related_model', field.related.model)
+            related_objects = related_model.objects.all()
             if(related_objects[:raw_id_threshold].count() < raw_id_threshold):
                 yield field.name
 
@@ -174,7 +175,8 @@ class AdminModel(object):
         raw_id_threshold = self.raw_id_threshold
         list_filter_threshold = self.list_filter_threshold
         max_count = max(list_filter_threshold, raw_id_threshold)
-        related_count = field.related.parent_model.objects.all()
+        related_model = getattr(field.related, 'related_model', field.related.model)
+        related_count = related_model.objects.all()
         related_count = related_count[:max_count].count()
 
         if related_count >= raw_id_threshold:


### PR DESCRIPTION
Updated to new way of retrieving the source model as recommended by Django: https://docs.djangoproject.com/en/dev/releases/1.8/#model-attribute-on-private-model-relations